### PR TITLE
Fix manuals table markup

### DIFF
--- a/VolvoPost/manuals.html
+++ b/VolvoPost/manuals.html
@@ -33,20 +33,20 @@
       <tbody>
         <!--XC40s-->
         <tr>
-          <td rowspan="3">2025 XC40</td>
+          <td>2025 XC40</td>
           <td>All</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/xc40-mild-hybrid/24w46/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
         </tr>
 <tr>
-          <td rowspan="3">2026 XC40</td>
+          <td>2026 XC40</td>
           <td>All</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/xc40-mild-hybrid/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
         </tr>
         <!--XC60s-->
         <tr>
-          <td rowspan="3">2025 XC60</td>
+          <td rowspan="2">2025 XC60</td>
           <td>B5</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/xc60/24w46/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
@@ -57,7 +57,7 @@
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
         </tr>
         <tr>
-          <td rowspan="3">2026 XC60</td>
+          <td rowspan="2">2026 XC60</td>
           <td>B5</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/xc60/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
@@ -69,7 +69,7 @@
         </tr>
         <!--XC90s-->
         <tr>
-          <td rowspan="3"> 2025 XC90</td>
+          <td rowspan="2"> 2025 XC90</td>
           <td>B6/B6</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/xc90/24w46/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
@@ -80,7 +80,7 @@
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
         </tr>
         <tr>
-          <td rowspan="3"> 2026 XC90</td>
+          <td rowspan="2"> 2026 XC90</td>
           <td>B6/B6</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/xc90/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
@@ -92,20 +92,20 @@
         </tr>
         <!--EX30-->
         <tr>
-          <td rowspan="2">2025 EX30</td>
+          <td>2025 EX30</td>
           <td>All</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/ex30/24w17/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20Fully%20Electric.pdf">View</a></td>
         </tr>
         <tr>
-          <td rowspan="2">2026 EX30</td>
+          <td>2026 EX30</td>
           <td>All</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/ex30/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20Fully%20Electric.pdf">View</a></td>
         </tr>
         <!--EX40/EC40-->
         <tr>
-          <td rowspan="2">2026 EX40/EC40</td>
+          <td>2026 EX40/EC40</td>
           <td>All</td>
           <td><a href="https://www.volvocars.com/en-ca/support/car/ex40/">View</a></td>
           <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20Fully%20Electric.pdf">View</a></td>


### PR DESCRIPTION
## Summary
- correct incorrect rowspan usage in `manuals.html`
- ensure trailing newline

## Testing
- `python3 -m http.server 8000` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6855c04064048320817a96dbab2b97f1