### PR TITLE
Add interactive trim and manual info

### DIFF
--- a/VolvoPost/ex90.html
+++ b/VolvoPost/ex90.html
@@ -23,15 +23,60 @@
       <img src="images/EX90.webp" alt="Volvo EX90 electric SUV">
       <h2>EX90</h2>
       <p class="model-desc">All-electric SUV introducing Volvo's latest driver-assistance and battery technology.</p>
-      <ul class="trim-list">
-        <li><strong>Plus:</strong> Dual-motor AWD, 14.5" center display, Pilot Assist</li>
-        <li><strong>Ultra:</strong> LiDAR with 360&deg; sensing, Bowers &amp; Wilkins audio, laminated side windows</li>
-      </ul>
+      <label for="trim-select">Choose Trim:</label>
+      <select id="trim-select" class="trim-select">
+        <option value="Plus">Plus</option>
+        <option value="Ultra">Ultra</option>
+      </select>
+      <div id="trim-details"></div>
+      <p>Choose Color:</p>
+      <div class="color-options">
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+      </div>
+      <p id="color-name"></p>
+    </div>
+
+    <div id="manual-links">
+      <table class="manual-table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Trim</th>
+            <th>Owner's Manual</th>
+            <th>Service Manual</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>2025 EX90</td>
+            <td>All</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/ex90/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20Fully%20Electric.pdf">View</a></td>
+          </tr>
+          <tr>
+            <td>2026 EX90</td>
+            <td>All</td>
+            <td><a href="#">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20Fully%20Electric.pdf">View</a></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
     <p>&copy; 2025 Volvo Ownership Experience | EX90</p>
   </footer>
+  <script src="script.js"></script>
+  <script>
+    initModelPage({
+      trims: {
+        'Plus': 'Dual-motor AWD, 14.5" center display, Pilot Assist',
+        'Ultra': 'LiDAR with 360° sensing, Bowers & Wilkins audio, laminated side windows'
+      }
+    });
+  </script>
 </body>
 </html>

--- a/VolvoPost/main.css
+++ b/VolvoPost/main.css
@@ -263,3 +263,35 @@ footer {
   text-decoration: underline;
 }
 
+
+/* Trim and color selection */
+.trim-select {
+  margin-top: 1em;
+  padding: 0.4em;
+  font-size: 1em;
+}
+#trim-details {
+  margin-top: 0.5em;
+  font-size: 0.9em;
+}
+.color-options {
+  display: flex;
+  justify-content: center;
+  margin-top: 1em;
+}
+.color-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  margin: 0 4px;
+  border: 2px solid #ccc;
+  cursor: pointer;
+}
+.color-swatch.selected {
+  border-color: var(--accent);
+}
+#color-name {
+  text-align: center;
+  font-size: 0.9em;
+  margin-top: 0.5em;
+}

--- a/VolvoPost/script.js
+++ b/VolvoPost/script.js
@@ -1,0 +1,23 @@
+function initModelPage(data) {
+  const swatches = document.querySelectorAll('.color-swatch');
+  const colorName = document.getElementById('color-name');
+  swatches.forEach(btn => {
+    btn.style.backgroundColor = btn.dataset.color;
+    btn.addEventListener('click', () => {
+      swatches.forEach(b => b.classList.remove('selected'));
+      btn.classList.add('selected');
+      colorName.textContent = btn.dataset.name;
+    });
+  });
+
+  const trimSelect = document.getElementById('trim-select');
+  const trimDetails = document.getElementById('trim-details');
+  if (trimSelect && trimDetails && data.trims) {
+    const updateTrim = () => {
+      const t = trimSelect.value;
+      trimDetails.textContent = data.trims[t] || '';
+    };
+    trimSelect.addEventListener('change', updateTrim);
+    updateTrim();
+  }
+}

--- a/VolvoPost/sedans.html
+++ b/VolvoPost/sedans.html
@@ -23,16 +23,68 @@
       <img src="images/V90.jpg" alt="Volvo V90 wagon">
       <h2>Sedans &amp; Wagons</h2>
       <p class="model-desc">Elegant sedan and wagon line-up designed for comfortable long-distance travel.</p>
-      <ul class="trim-list">
-        <li><strong>S60 Core:</strong> Digital driver display, heated front seats</li>
-        <li><strong>S60 Plus:</strong> Leather upholstery, premium sound, front park assist</li>
-        <li><strong>S90 Ultimate:</strong> Extended wheelbase, Nappa leather, advanced driver aids</li>
-      </ul>
+      <label for="trim-select">Choose Trim:</label>
+      <select id="trim-select" class="trim-select">
+        <option value="S60 Core">S60 Core</option>
+        <option value="S60 Plus">S60 Plus</option>
+        <option value="S90 Ultimate">S90 Ultimate</option>
+      </select>
+      <div id="trim-details"></div>
+      <p>Choose Color:</p>
+      <div class="color-options">
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+      </div>
+      <p id="color-name"></p>
+    </div>
+
+    <div id="manual-links">
+      <table class="manual-table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Trim</th>
+            <th>Owner's Manual</th>
+            <th>Service Manual</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>S60 Core</td>
+            <td>Gas</td>
+            <td><a href="#">View</a></td>
+            <td><a href="#">View</a></td>
+          </tr>
+          <tr>
+            <td>S60 Plus</td>
+            <td>Gas</td>
+            <td><a href="#">View</a></td>
+            <td><a href="#">View</a></td>
+          </tr>
+          <tr>
+            <td>S90 Ultimate</td>
+            <td>Gas</td>
+            <td><a href="#">View</a></td>
+            <td><a href="#">View</a></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
     <p>&copy; 2025 Volvo Ownership Experience | Sedans &amp; Wagons</p>
   </footer>
+  <script src="script.js"></script>
+  <script>
+    initModelPage({
+      trims: {
+        'S60 Core': 'Digital driver display, heated front seats',
+        'S60 Plus': 'Leather upholstery, premium sound, front park assist',
+        'S90 Ultimate': 'Extended wheelbase, Nappa leather, advanced driver aids'
+      }
+    });
+  </script>
 </body>
 </html>

--- a/VolvoPost/xc40.html
+++ b/VolvoPost/xc40.html
@@ -23,16 +23,62 @@
       <img src="images/VolvoXC40.jpg" alt="Volvo XC40 compact SUV">
       <h2>XC40</h2>
       <p class="model-desc">Compact SUV that mixes clever storage solutions with a tall seating position.</p>
-      <ul class="trim-list">
-        <li><strong>Core:</strong> Google built-in, 12" driver display, LED headlights</li>
-        <li><strong>Plus:</strong> Panoramic roof, power front seats, leatherette upholstery</li>
-        <li><strong>Ultimate:</strong> 360&deg; camera, Pilot Assist, Harman Kardon audio</li>
-      </ul>
+      <label for="trim-select">Choose Trim:</label>
+      <select id="trim-select" class="trim-select">
+        <option value="Core">Core</option>
+        <option value="Plus">Plus</option>
+        <option value="Ultimate">Ultimate</option>
+      </select>
+      <div id="trim-details"></div>
+      <p>Choose Color:</p>
+      <div class="color-options">
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+      </div>
+      <p id="color-name"></p>
+    </div>
+
+    <div id="manual-links">
+      <table class="manual-table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Trim</th>
+            <th>Owner's Manual</th>
+            <th>Service Manual</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>2025 XC40</td>
+            <td>All</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc40-mild-hybrid/24w46/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+          <tr>
+            <td>2026 XC40</td>
+            <td>All</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc40-mild-hybrid/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
     <p>&copy; 2025 Volvo Ownership Experience | XC40</p>
   </footer>
+  <script src="script.js"></script>
+  <script>
+    initModelPage({
+      trims: {
+        'Core': 'Google built-in, 12\" driver display, LED headlights',
+        'Plus': 'Panoramic roof, power front seats, leatherette upholstery',
+        'Ultimate': '360° camera, Pilot Assist, Harman Kardon audio'
+      }
+    });
+  </script>
 </body>
 </html>

--- a/VolvoPost/xc60.html
+++ b/VolvoPost/xc60.html
@@ -23,16 +23,72 @@
       <img src="images/VolvoXC60.jpg" alt="Volvo XC60 midsize SUV">
       <h2>XC60</h2>
       <p class="model-desc">Midsize SUV blending refined handling with modern safety technology.</p>
-      <ul class="trim-list">
-        <li><strong>Core:</strong> 9" touchscreen, Blind Spot Information System, power tailgate</li>
-        <li><strong>Plus:</strong> Keyless entry, leather upholstery, four-zone climate control</li>
-        <li><strong>Ultimate:</strong> Air suspension, Bowers &amp; Wilkins sound, 360&deg; camera</li>
-      </ul>
+      <label for="trim-select">Choose Trim:</label>
+      <select id="trim-select" class="trim-select">
+        <option value="Core">Core</option>
+        <option value="Plus">Plus</option>
+        <option value="Ultimate">Ultimate</option>
+      </select>
+      <div id="trim-details"></div>
+      <p>Choose Color:</p>
+      <div class="color-options">
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+      </div>
+      <p id="color-name"></p>
+    </div>
+
+    <div id="manual-links">
+      <table class="manual-table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Trim</th>
+            <th>Owner's Manual</th>
+            <th>Service Manual</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="2">2025 XC60</td>
+            <td>B5</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc60/24w46/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+          <tr>
+            <td>T8</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc60-plug-in-hybrid/24w46/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+          <tr>
+            <td rowspan="2">2026 XC60</td>
+            <td>B5</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc60/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+          <tr>
+            <td>T8</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc60-plug-in-hybrid/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
     <p>&copy; 2025 Volvo Ownership Experience | XC60</p>
   </footer>
+  <script src="script.js"></script>
+  <script>
+    initModelPage({
+      trims: {
+        'Core': '9" touchscreen, Blind Spot Information System, power tailgate',
+        'Plus': 'Keyless entry, leather upholstery, four-zone climate control',
+        'Ultimate': 'Air suspension, Bowers & Wilkins sound, 360° camera'
+      }
+    });
+  </script>
 </body>
 </html>

--- a/VolvoPost/xc90.html
+++ b/VolvoPost/xc90.html
@@ -23,16 +23,72 @@
       <img src="images/xc90.webp" alt="Volvo XC90 three-row SUV">
       <h2>XC90</h2>
       <p class="model-desc">Flagship SUV with seating for seven and a choice of mild-hybrid or plug-in power.</p>
-      <ul class="trim-list">
-        <li><strong>Core:</strong> Panoramic roof, Google built-in, seven-seat layout</li>
-        <li><strong>Plus:</strong> Leather seats, Pilot Assist with Adaptive Cruise Control, 360&deg; camera</li>
-        <li><strong>Ultimate:</strong> Nappa leather, crystal shift knob, air suspension</li>
-      </ul>
+      <label for="trim-select">Choose Trim:</label>
+      <select id="trim-select" class="trim-select">
+        <option value="Core">Core</option>
+        <option value="Plus">Plus</option>
+        <option value="Ultimate">Ultimate</option>
+      </select>
+      <div id="trim-details"></div>
+      <p>Choose Color:</p>
+      <div class="color-options">
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+      </div>
+      <p id="color-name"></p>
+    </div>
+
+    <div id="manual-links">
+      <table class="manual-table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Trim</th>
+            <th>Owner's Manual</th>
+            <th>Service Manual</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="2">2025 XC90</td>
+            <td>B6/B6</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc90/24w46/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+          <tr>
+            <td>T8</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc90-plug-in-hybrid/24w46/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+          <tr>
+            <td rowspan="2">2026 XC90</td>
+            <td>B5/B6</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc90/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+          <tr>
+            <td>T8</td>
+            <td><a href="https://www.volvocars.com/en-ca/support/car/xc90-plug-in-hybrid/">View</a></td>
+            <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
     <p>&copy; 2025 Volvo Ownership Experience | XC90</p>
   </footer>
+  <script src="script.js"></script>
+  <script>
+    initModelPage({
+      trims: {
+        'Core': 'Panoramic roof, Google built-in, seven-seat layout',
+        'Plus': 'Leather seats, Pilot Assist with Adaptive Cruise Control, 360° camera',
+        'Ultimate': 'Nappa leather, crystal shift knob, air suspension'
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add script for trim and color selectors
- support trim selection and color swatches on each model page
- embed owner and service manuals directly within model pages
- style trim and color widgets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855e78f6b80832084707a716d80a55a