### PR TITLE
Move warranty info and update color images

### DIFF
--- a/VolvoPost/ex30.html
+++ b/VolvoPost/ex30.html
@@ -31,9 +31,9 @@
       <div id="trim-details"></div>
       <p>Choose Color:</p>
       <div class="color-options">
-        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
-        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
-        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue" data-image="https://www.volvocars.com/images/ex30-denim-blue.jpg"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver" data-image="https://www.volvocars.com/images/ex30-silver.jpg"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black" data-image="https://www.volvocars.com/images/ex30-black.jpg"></button>
       </div>
       <p id="color-name"></p>
     </div>
@@ -64,6 +64,13 @@
         </tbody>
       </table>
     </div>
+    <div id="warranty-links">
+      <h3>Warranty Manuals</h3>
+      <ul>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2025 EX30 Warranty</a></li>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2026 EX30 Warranty</a></li>
+      </ul>
+    </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
@@ -80,3 +87,4 @@
   </script>
 </body>
 </html>
+

--- a/VolvoPost/ex40.html
+++ b/VolvoPost/ex40.html
@@ -31,9 +31,9 @@
       <div id="trim-details"></div>
       <p>Choose Color:</p>
       <div class="color-options">
-        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
-        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
-        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue" data-image="https://www.volvocars.com/images/ex40-denim-blue.jpg"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver" data-image="https://www.volvocars.com/images/ex40-silver.jpg"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black" data-image="https://www.volvocars.com/images/ex40-black.jpg"></button>
       </div>
       <p id="color-name"></p>
     </div>
@@ -58,6 +58,12 @@
         </tbody>
       </table>
     </div>
+    <div id="warranty-links">
+      <h3>Warranty Manual</h3>
+      <ul>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2026 EX40 Warranty</a></li>
+      </ul>
+    </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
@@ -74,3 +80,5 @@
   </script>
 </body>
 </html>
+
+

--- a/VolvoPost/ex90.html
+++ b/VolvoPost/ex90.html
@@ -31,9 +31,9 @@
       <div id="trim-details"></div>
       <p>Choose Color:</p>
       <div class="color-options">
-        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
-        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
-        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue" data-image="https://www.volvocars.com/images/ex90-denim-blue.jpg"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver" data-image="https://www.volvocars.com/images/ex90-silver.jpg"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black" data-image="https://www.volvocars.com/images/ex90-black.jpg"></button>
       </div>
       <p id="color-name"></p>
     </div>
@@ -64,6 +64,13 @@
         </tbody>
       </table>
     </div>
+    <div id="warranty-links">
+      <h3>Warranty Manuals</h3>
+      <ul>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2025 EX90 Warranty</a></li>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2026 EX90 Warranty</a></li>
+      </ul>
+    </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
@@ -80,3 +87,5 @@
   </script>
 </body>
 </html>
+
+

--- a/VolvoPost/quick-tips.html
+++ b/VolvoPost/quick-tips.html
@@ -19,18 +19,6 @@
     <h1>Volvo Quick Tips & Resources</h1>
   </header>
   <main class="container">
-    <section class="model-links">
-      <h2>Model-SpecificWarranty Information</h2>
-      <div class="model-grid">
-        <a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC40</a>
-        <a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC60 B5</a>
-        <a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC60 T8</a>
-        <a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC90 B5/B6</a>
-        <a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC90 T8</a>
-        <a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2025 EX30</a>
-        <a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2025 EX90</a>
-      </div>
-    </section>
 
     <section class="tips-grid">
       <article class="tip-item">
@@ -51,3 +39,4 @@
   </footer>
 </body>
 </html>
+

--- a/VolvoPost/script.js
+++ b/VolvoPost/script.js
@@ -7,6 +7,10 @@ function initModelPage(data) {
       swatches.forEach(b => b.classList.remove('selected'));
       btn.classList.add('selected');
       colorName.textContent = btn.dataset.name;
+      const img = document.querySelector('.model-card img');
+      if (btn.dataset.image && img) {
+        img.src = btn.dataset.image;
+      }
     });
   });
 
@@ -21,3 +25,4 @@ function initModelPage(data) {
     updateTrim();
   }
 }
+

--- a/VolvoPost/sedans.html
+++ b/VolvoPost/sedans.html
@@ -32,9 +32,9 @@
       <div id="trim-details"></div>
       <p>Choose Color:</p>
       <div class="color-options">
-        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
-        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
-        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue" data-image="https://www.volvocars.com/images/sedan-denim-blue.jpg"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver" data-image="https://www.volvocars.com/images/sedan-silver.jpg"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black" data-image="https://www.volvocars.com/images/sedan-black.jpg"></button>
       </div>
       <p id="color-name"></p>
     </div>
@@ -71,6 +71,12 @@
         </tbody>
       </table>
     </div>
+    <div id="warranty-links">
+      <h3>Warranty Manual</h3>
+      <ul>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 Warranty Manual</a></li>
+      </ul>
+    </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
@@ -88,3 +94,5 @@
   </script>
 </body>
 </html>
+
+

--- a/VolvoPost/xc40.html
+++ b/VolvoPost/xc40.html
@@ -32,9 +32,9 @@
       <div id="trim-details"></div>
       <p>Choose Color:</p>
       <div class="color-options">
-        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
-        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
-        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue" data-image="https://www.volvocars.com/images/xc40-denim-blue.jpg"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver" data-image="https://www.volvocars.com/images/xc40-silver.jpg"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black" data-image="https://www.volvocars.com/images/xc40-black.jpg"></button>
       </div>
       <p id="color-name"></p>
     </div>
@@ -65,6 +65,12 @@
         </tbody>
       </table>
     </div>
+    <div id="warranty-links">
+      <h3>Warranty Manual</h3>
+      <ul>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC40 Warranty</a></li>
+      </ul>
+    </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
@@ -82,3 +88,5 @@
   </script>
 </body>
 </html>
+
+

--- a/VolvoPost/xc60.html
+++ b/VolvoPost/xc60.html
@@ -32,9 +32,9 @@
       <div id="trim-details"></div>
       <p>Choose Color:</p>
       <div class="color-options">
-        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
-        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
-        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue" data-image="https://www.volvocars.com/images/xc60-denim-blue.jpg"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver" data-image="https://www.volvocars.com/images/xc60-silver.jpg"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black" data-image="https://www.volvocars.com/images/xc60-black.jpg"></button>
       </div>
       <p id="color-name"></p>
     </div>
@@ -75,6 +75,12 @@
         </tbody>
       </table>
     </div>
+    <div id="warranty-links">
+      <h3>Warranty Manual</h3>
+      <ul>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC60 Warranty</a></li>
+      </ul>
+    </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
@@ -92,3 +98,5 @@
   </script>
 </body>
 </html>
+
+

--- a/VolvoPost/xc90.html
+++ b/VolvoPost/xc90.html
@@ -32,9 +32,9 @@
       <div id="trim-details"></div>
       <p>Choose Color:</p>
       <div class="color-options">
-        <button class="color-swatch" data-color="#003057" data-name="Denim Blue"></button>
-        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver"></button>
-        <button class="color-swatch" data-color="#000000" data-name="Black"></button>
+        <button class="color-swatch" data-color="#003057" data-name="Denim Blue" data-image="https://www.volvocars.com/images/xc90-denim-blue.jpg"></button>
+        <button class="color-swatch" data-color="#b7b7b7" data-name="Silver" data-image="https://www.volvocars.com/images/xc90-silver.jpg"></button>
+        <button class="color-swatch" data-color="#000000" data-name="Black" data-image="https://www.volvocars.com/images/xc90-black.jpg"></button>
       </div>
       <p id="color-name"></p>
     </div>
@@ -75,6 +75,12 @@
         </tbody>
       </table>
     </div>
+    <div id="warranty-links">
+      <h3>Warranty Manual</h3>
+      <ul>
+        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC90 Warranty</a></li>
+      </ul>
+    </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
   <footer>
@@ -92,3 +98,5 @@
   </script>
 </body>
 </html>
+
+


### PR DESCRIPTION
## Summary
- remove warranty details from quick tips page
- add warranty links to each model page
- update color swatches with image URLs
- update script to swap images when colors are selected

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_6855ee40d5e08320b8ad4d8ff4ab7332