### PR TITLE
Add accessory grids to model pages

### DIFF
--- a/VolvoPost/ex30.html
+++ b/VolvoPost/ex30.html
@@ -81,7 +81,13 @@
     </div>
       <div id="accessory-links">
         <h3>Genuine Accessories</h3>
-        <p><a href="https://accessories.volvocars.com/en-us/EX30" target="_blank">Shop accessories for the EX30</a></p>
+        <ul class="accessory-grid">
+          <li><a href="https://accessories.volvocars.com/en-us/EX30/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX30/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX30/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX30/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+        </ul>
+        <p><a href="https://accessories.volvocars.com/en-us/EX30" target="_blank">Browse full catalog</a></p>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/ex40.html
+++ b/VolvoPost/ex40.html
@@ -79,7 +79,13 @@
     </div>
       <div id="accessory-links">
         <h3>Genuine Accessories</h3>
-        <p><a href="https://accessories.volvocars.com/en-us/EX40" target="_blank">Shop accessories for the EX40</a></p>
+        <ul class="accessory-grid">
+          <li><a href="https://accessories.volvocars.com/en-us/EX40/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX40/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX40/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX40/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+        </ul>
+        <p><a href="https://accessories.volvocars.com/en-us/EX40" target="_blank">Browse full catalog</a></p>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/ex90.html
+++ b/VolvoPost/ex90.html
@@ -85,7 +85,13 @@
     </div>
       <div id="accessory-links">
         <h3>Genuine Accessories</h3>
-        <p><a href="https://accessories.volvocars.com/en-us/EX90" target="_blank">Shop accessories for the EX90</a></p>
+        <ul class="accessory-grid">
+          <li><a href="https://accessories.volvocars.com/en-us/EX90/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX90/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX90/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/EX90/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+        </ul>
+        <p><a href="https://accessories.volvocars.com/en-us/EX90" target="_blank">Browse full catalog</a></p>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/main.css
+++ b/VolvoPost/main.css
@@ -350,3 +350,33 @@ footer {
 .spec-table tr:nth-child(even) {
   background-color: #f9f9f9;
 }
+
+/* Accessory grid styles */
+.accessory-grid {
+  list-style: none;
+  padding: 0;
+  margin-top: 1em;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75em;
+}
+
+.accessory-grid li {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 0.75em;
+  text-align: center;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+  transition: transform 0.3s ease;
+}
+
+.accessory-grid li:hover {
+  transform: translateY(-4px);
+}
+
+.accessory-grid a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}

--- a/VolvoPost/s60.html
+++ b/VolvoPost/s60.html
@@ -83,7 +83,13 @@
     </div>
     <div id="accessory-links">
       <h3>Genuine Accessories</h3>
-      <p><a href="https://accessories.volvocars.com/en-us/S60" target="_blank">Shop accessories for the S60</a></p>
+      <ul class="accessory-grid">
+        <li><a href="https://accessories.volvocars.com/en-us/S60/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/S60/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/S60/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/S60/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+      </ul>
+      <p><a href="https://accessories.volvocars.com/en-us/S60" target="_blank">Browse full catalog</a></p>
     </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/s90.html
+++ b/VolvoPost/s90.html
@@ -76,7 +76,13 @@
     </div>
       <div id="accessory-links">
         <h3>Genuine Accessories</h3>
-        <p><a href="https://accessories.volvocars.com/en-us/S90" target="_blank">Shop accessories for the S90</a></p>
+        <ul class="accessory-grid">
+          <li><a href="https://accessories.volvocars.com/en-us/S90/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/S90/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/S90/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/S90/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+        </ul>
+        <p><a href="https://accessories.volvocars.com/en-us/S90" target="_blank">Browse full catalog</a></p>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/v60.html
+++ b/VolvoPost/v60.html
@@ -83,7 +83,13 @@
     </div>
     <div id="accessory-links">
       <h3>Genuine Accessories</h3>
-      <p><a href="https://accessories.volvocars.com/en-us/V60" target="_blank">Shop accessories for the V60</a></p>
+      <ul class="accessory-grid">
+        <li><a href="https://accessories.volvocars.com/en-us/V60/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/V60/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/V60/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/V60/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+      </ul>
+      <p><a href="https://accessories.volvocars.com/en-us/V60" target="_blank">Browse full catalog</a></p>
     </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/v90.html
+++ b/VolvoPost/v90.html
@@ -71,7 +71,13 @@
     </div>
       <div id="accessory-links">
         <h3>Genuine Accessories</h3>
-        <p><a href="https://accessories.volvocars.com/en-us/V90" target="_blank">Shop accessories for the V90</a></p>
+        <ul class="accessory-grid">
+          <li><a href="https://accessories.volvocars.com/en-us/V90/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/V90/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/V90/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/V90/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+        </ul>
+        <p><a href="https://accessories.volvocars.com/en-us/V90" target="_blank">Browse full catalog</a></p>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/xc40.html
+++ b/VolvoPost/xc40.html
@@ -86,7 +86,13 @@
     </div>
     <div id="accessory-links">
       <h3>Genuine Accessories</h3>
-      <p><a href="https://accessories.volvocars.com/en-us/XC40" target="_blank">Shop accessories for the XC40</a></p>
+      <ul class="accessory-grid">
+        <li><a href="https://accessories.volvocars.com/en-us/XC40/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/XC40/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/XC40/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+        <li><a href="https://accessories.volvocars.com/en-us/XC40/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+      </ul>
+      <p><a href="https://accessories.volvocars.com/en-us/XC40" target="_blank">Browse full catalog</a></p>
     </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/xc60.html
+++ b/VolvoPost/xc60.html
@@ -94,7 +94,13 @@
     </div>
       <div id="accessory-links">
         <h3>Genuine Accessories</h3>
-        <p><a href="https://accessories.volvocars.com/en-us/XC60" target="_blank">Shop accessories for the XC60</a></p>
+        <ul class="accessory-grid">
+          <li><a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+        </ul>
+        <p><a href="https://accessories.volvocars.com/en-us/XC60" target="_blank">Browse full catalog</a></p>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>

--- a/VolvoPost/xc90.html
+++ b/VolvoPost/xc90.html
@@ -93,7 +93,13 @@
     </div>
       <div id="accessory-links">
         <h3>Genuine Accessories</h3>
-        <p><a href="https://accessories.volvocars.com/en-us/XC90" target="_blank">Shop accessories for the XC90</a></p>
+        <ul class="accessory-grid">
+          <li><a href="https://accessories.volvocars.com/en-us/XC90/Accessories/Document/VCC-515146" target="_blank">Roof Rack</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/XC90/Accessories/Document/VCC-516502" target="_blank">All-Weather Mats</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/XC90/Accessories/Document/VCC-517743" target="_blank">Cargo Organizer</a></li>
+          <li><a href="https://accessories.volvocars.com/en-us/XC90/Accessories/Document/VCC-518234" target="_blank">Sunshade</a></li>
+        </ul>
+        <p><a href="https://accessories.volvocars.com/en-us/XC90" target="_blank">Browse full catalog</a></p>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>


### PR DESCRIPTION
## Summary
- include a new `accessory-grid` style in `main.css`
- show several accessory links on each model page

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6866a793e5c883208d804c54cd243dbf