### PR TITLE
Fix XC60 accessories section

### DIFF
--- a/VolvoPost/main.css
+++ b/VolvoPost/main.css
@@ -380,3 +380,31 @@ footer {
   text-decoration: none;
   font-weight: 600;
 }
+
+.accessory-grid img {
+  width: 100%;
+  height: 100px;
+  object-fit: cover;
+  margin-bottom: 0.5em;
+}
+
+.catalog-links {
+  text-align: center;
+  margin-top: 1em;
+}
+
+.catalog-links a {
+  display: inline-block;
+  margin: 0.3em;
+  padding: 0.6em 1.2em;
+  background-color: var(--primary);
+  color: white;
+  text-decoration: none;
+  border-radius: 6px;
+  font-weight: 600;
+  transition: background 0.3s ease;
+}
+
+.catalog-links a:hover {
+  background-color: var(--highlight);
+}

--- a/VolvoPost/xc60.html
+++ b/VolvoPost/xc60.html
@@ -93,15 +93,37 @@
       </ul>
     </div>
       <div id="accessory-links">
-        <h3>Avaliable Accessories</h3>
+        <h3>Available Accessories</h3>
         <ul class="accessory-grid">
-          <li><a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-515146" img src="https://prismedia.volvocars.com/images/cf2e4ec6-c8bf-4bca-ae15-2018bebc3200/Bicycle_holder_aluminium_V60_HD.jpg?w=0" target="_blank">Bike Rack for 1 Bike, roof</a></li>
-          <li><a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-516502" img src="https://prismedia.volvocars.com/images/7e77a511-4eba-4f12-a732-b193c3978e92/Roof_tent_A01601_7_HD.jpg?w=0" target="_blank">Roof Tent</a></li>
-          <li><a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-517743" img src="https://prismedia.volvocars.com/images/fd3f1129-92bd-470c-87b7-1b16be1fbac3/Ski_snowboard_holder_sliding_S60_HD.jpg?w=0" target="_blank">Ski/Snowboard Holder</a></li>
-          <li><a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-518234" img src="https://prismedia.volvocars.com/images/46613b4b-7271-403a-b951-99f33c282029/Kayak_holder_A01593_1_HD.jpg?w=0" target="_blank">Kayak Holder</a></li>
+          <li>
+            <a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-515146" target="_blank">
+              <img src="https://prismedia.volvocars.com/images/cf2e4ec6-c8bf-4bca-ae15-2018bebc3200/Bicycle_holder_aluminium_V60_HD.jpg?w=0" alt="Bike Rack">
+              Bike Rack for 1 Bike, roof
+            </a>
+          </li>
+          <li>
+            <a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-516502" target="_blank">
+              <img src="https://prismedia.volvocars.com/images/7e77a511-4eba-4f12-a732-b193c3978e92/Roof_tent_A01601_7_HD.jpg?w=0" alt="Roof Tent">
+              Roof Tent
+            </a>
+          </li>
+          <li>
+            <a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-517743" target="_blank">
+              <img src="https://prismedia.volvocars.com/images/fd3f1129-92bd-470c-87b7-1b16be1fbac3/Ski_snowboard_holder_sliding_S60_HD.jpg?w=0" alt="Ski/Snowboard Holder">
+              Ski/Snowboard Holder
+            </a>
+          </li>
+          <li>
+            <a href="https://accessories.volvocars.com/en-us/XC60/Accessories/Document/VCC-518234" target="_blank">
+              <img src="https://prismedia.volvocars.com/images/46613b4b-7271-403a-b951-99f33c282029/Kayak_holder_A01593_1_HD.jpg?w=0" alt="Kayak Holder">
+              Kayak Holder
+            </a>
+          </li>
         </ul>
-        <p><a href="https://usparts.volvocars.com/accessories/Volvo_2025_XC60.html" target="_blank">2025 full catalog</a></p>
-        <p><a href="https://usparts.volvocars.com/accessories/Volvo_2026_XC60.html" target="_blank">2026 full catalog</a></p>
+        <div class="catalog-links">
+          <a href="https://usparts.volvocars.com/accessories/Volvo_2025_XC60.html" target="_blank">2025 Full Catalog</a>
+          <a href="https://usparts.volvocars.com/accessories/Volvo_2026_XC60.html" target="_blank">2026 Full Catalog</a>
+        </div>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>


### PR DESCRIPTION
## Summary
- improve accessory list in `xc60.html` by showing images
- tidy heading and add styled links for 2025/2026 catalog
- add CSS rules for accessory images and catalog links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866b17017d48320aafe228bb96fe484