### PR TITLE
Add model year choice for each model

### DIFF
--- a/VolvoPost/ex30.html
+++ b/VolvoPost/ex30.html
@@ -57,13 +57,13 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="year-2025">
             <td>2025 EX30</td>
             <td>All</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/ex30/24w17/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20Fully%20Electric.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2026">
             <td>2026 EX30</td>
             <td>All</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/ex30/">View</a></td>
@@ -75,8 +75,8 @@
     <div id="warranty-links">
       <h3>Warranty Manuals</h3>
       <ul>
-        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2025 EX30 Warranty</a></li>
-        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2026 EX30 Warranty</a></li>
+        <li class="year-2025"><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2025 EX30 Warranty</a></li>
+        <li class="year-2026"><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2026 EX30 Warranty</a></li>
       </ul>
     </div>
       <div id="accessory-links">
@@ -94,8 +94,8 @@
       </ul>
     </div>
 <div class="catalog-links">
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2025_EX30.html" target="_blank">2025 Full Catalog</a>
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2026_EX30.html" target="_blank">2026 Full Catalog</a>
+          <a class="year-2025" href="https://usparts.volvocars.com/accessories/Volvo_2025_EX30.html" target="_blank">2025 Full Catalog</a>
+          <a class="year-2026" href="https://usparts.volvocars.com/accessories/Volvo_2026_EX30.html" target="_blank">2026 Full Catalog</a>
         </div>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
@@ -115,6 +115,7 @@
         'Ultra': 'images/ex30-ultra.jpg'
       }
     });
+    askModelYear();
   </script>
 </body>
 </html>

--- a/VolvoPost/ex40.html
+++ b/VolvoPost/ex40.html
@@ -114,6 +114,7 @@
         'Ultra': 'images/ex40-ultra.jpg'
       }
     });
+    askModelYear();
   </script>
 </body>
 </html>

--- a/VolvoPost/ex90.html
+++ b/VolvoPost/ex90.html
@@ -61,13 +61,13 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="year-2025">
             <td>2025 EX90</td>
             <td>All</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/ex90/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20Fully%20Electric.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2026">
             <td>2026 EX90</td>
             <td>All</td>
             <td><a href="#">View</a></td>
@@ -79,8 +79,8 @@
     <div id="warranty-links">
       <h3>Warranty Manuals</h3>
       <ul>
-        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2025 EX90 Warranty</a></li>
-        <li><a href="" target="_blank">2026 EX90 Warranty (Not Yet Available)</a></li>
+        <li class="year-2025"><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_MY2025_Fully_Elec_Wty_Manual.pdf" target="_blank">2025 EX90 Warranty</a></li>
+        <li class="year-2026"><a href="" target="_blank">2026 EX90 Warranty (Not Yet Available)</a></li>
       </ul>
     </div>
       <div id="accessory-links">
@@ -97,8 +97,8 @@
       </ul>
     </div>
 <div class="catalog-links">
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2025_EX90.html" target="_blank">2025 Full Catalog</a>
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2026_EX90.html" target="_blank">2026 Full Catalog</a>
+          <a class="year-2025" href="https://usparts.volvocars.com/accessories/Volvo_2025_EX90.html" target="_blank">2025 Full Catalog</a>
+          <a class="year-2026" href="https://usparts.volvocars.com/accessories/Volvo_2026_EX90.html" target="_blank">2026 Full Catalog</a>
         </div>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
@@ -118,6 +118,7 @@
         'Ultra': 'images/ex90-ultra.jpg'
       }
     });
+    askModelYear();
   </script>
 </body>
 </html>

--- a/VolvoPost/script.js
+++ b/VolvoPost/script.js
@@ -32,3 +32,14 @@ function initModelPage(data) {
   }
 }
 
+function askModelYear() {
+  const year = prompt('Is your Volvo a 2025 or a 2026 model?');
+  if (!year) return;
+  document.querySelectorAll('.year-2025').forEach(el => {
+    el.style.display = year === '2025' ? '' : 'none';
+  });
+  document.querySelectorAll('.year-2026').forEach(el => {
+    el.style.display = year === '2026' ? '' : 'none';
+  });
+}
+

--- a/VolvoPost/xc40.html
+++ b/VolvoPost/xc40.html
@@ -63,13 +63,13 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="year-2025">
             <td>2025 XC40</td>
             <td>All</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc40-mild-hybrid/24w46/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2026">
             <td>2026 XC40</td>
             <td>All</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc40-mild-hybrid/">View</a></td>
@@ -81,7 +81,7 @@
     <div id="warranty-links">
       <h3>Warranty Manual</h3>
       <ul>
-        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC40 Warranty</a></li>
+        <li class="year-2025"><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC40 Warranty</a></li>
       </ul>
     </div>
     <div id="accessory-links">
@@ -103,8 +103,8 @@
       </ul>
     </div>
     <div class="catalog-links">
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2025_XC40.html" target="_blank">2025 Full Catalog</a>
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2026_XC40.html" target="_blank">2026 Full Catalog</a>
+          <a class="year-2025" href="https://usparts.volvocars.com/accessories/Volvo_2025_XC40.html" target="_blank">2025 Full Catalog</a>
+          <a class="year-2026" href="https://usparts.volvocars.com/accessories/Volvo_2026_XC40.html" target="_blank">2026 Full Catalog</a>
         </div>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
@@ -126,6 +126,7 @@
         'Ultra': 'images/xc40-ultra.jpg'
       }
     });
+    askModelYear();
   </script>
 </body>
 </html>

--- a/VolvoPost/xc60.html
+++ b/VolvoPost/xc60.html
@@ -61,24 +61,24 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="year-2025">
             <td rowspan="2">2025 XC60</td>
             <td>B5</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc60/24w46/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2025">
             <td>T8</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc60-plug-in-hybrid/24w46/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2026">
             <td rowspan="2">2026 XC60</td>
             <td>B5</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc60/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2026">
             <td>T8</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc60-plug-in-hybrid/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
@@ -89,7 +89,7 @@
     <div id="warranty-links">
       <h3>Warranty Manual</h3>
       <ul>
-        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC60 Warranty</a></li>
+        <li class="year-2025"><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC60 Warranty</a></li>
       </ul>
     </div>
       <div id="accessory-links">
@@ -129,8 +129,8 @@
       </ul>
     </div>
         <div class="catalog-links">
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2025_XC60.html" target="_blank">2025 Full Catalog</a>
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2026_XC60.html" target="_blank">2026 Full Catalog</a>
+          <a class="year-2025" href="https://usparts.volvocars.com/accessories/Volvo_2025_XC60.html" target="_blank">2025 Full Catalog</a>
+          <a class="year-2026" href="https://usparts.volvocars.com/accessories/Volvo_2026_XC60.html" target="_blank">2026 Full Catalog</a>
         </div>
       </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
@@ -152,6 +152,7 @@
         'Ultra': 'images/xc60-ultra.jpg'
       }
     });
+    askModelYear();
   </script>
 </body>
 </html>

--- a/VolvoPost/xc90.html
+++ b/VolvoPost/xc90.html
@@ -60,24 +60,24 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class="year-2025">
             <td rowspan="2">2025 XC90</td>
             <td>B6/B6</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc90/24w46/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2025">
             <td>T8</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc90-plug-in-hybrid/24w46/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2025%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2026">
             <td rowspan="2">2026 XC90</td>
             <td>B5/B6</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc90/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
           </tr>
-          <tr>
+          <tr class="year-2026">
             <td>T8</td>
             <td><a href="https://www.volvocars.com/en-ca/support/car/xc90-plug-in-hybrid/">View</a></td>
             <td><a href="https://volvornt.harte-hanks.com/VolvoVMR/VolvoMediaRepository/Images/FSM%20updated/2026%20FSM%20Maintenance%20Sheets%20PHEV%20MHEV.pdf">View</a></td>
@@ -88,7 +88,7 @@
     <div id="warranty-links">
       <h3>Warranty Manual</h3>
       <ul>
-        <li><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC90 Warranty</a></li>
+        <li class="year-2025"><a href="https://volvornt.harte-hanks.com/manuals/2025/Volvo_Wty_Manual_2025.pdf" target="_blank">2025 XC90 Warranty</a></li>
       </ul>
     </div>
       <div id="accessory-links">
@@ -109,8 +109,8 @@
       </ul>
     </div>
         <div class="catalog-links">
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2025_XC90.html" target="_blank">2025 Full Catalog</a>
-          <a href="https://usparts.volvocars.com/accessories/Volvo_2026_XC90.html" target="_blank">2026 Full Catalog</a>
+          <a class="year-2025" href="https://usparts.volvocars.com/accessories/Volvo_2025_XC90.html" target="_blank">2025 Full Catalog</a>
+          <a class="year-2026" href="https://usparts.volvocars.com/accessories/Volvo_2026_XC90.html" target="_blank">2026 Full Catalog</a>
         </div>
     <p style="text-align:center;font-size:0.9em;">Trim content may vary by model year. Contact your retailer for detailed specifications.</p>
   </main>
@@ -131,6 +131,7 @@
         'Ultimate': 'images/xc90-ultimate.jpg'
       }
     });
+    askModelYear();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- added `askModelYear` in `script.js` to prompt for 2025 vs 2026
- applied year-specific classes on EX30, XC40, XC60, XC90, and EX90 pages
- included `askModelYear()` call on all model pages

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_687007be6f7483209bf48969393de3a4