### PR TITLE
Allow trim-specific color images

### DIFF
--- a/VolvoPost/script.js
+++ b/VolvoPost/script.js
@@ -1,6 +1,7 @@
 function initModelPage(data) {
   const swatches = document.querySelectorAll('.color-swatch');
   const colorName = document.getElementById('color-name');
+  let selectedColor = null;
   let selectedColorImage = null;
   swatches.forEach(btn => {
     btn.style.backgroundColor = btn.dataset.color;
@@ -8,10 +9,17 @@ function initModelPage(data) {
       swatches.forEach(b => b.classList.remove('selected'));
       btn.classList.add('selected');
       colorName.textContent = btn.dataset.name;
+      selectedColor = btn.dataset.color;
       selectedColorImage = btn.dataset.image;
       const img = document.querySelector('.model-card img');
-      if (selectedColorImage && img) {
-        img.src = selectedColorImage;
+      if (img) {
+        if (data.trimColorImages && selectedTrim &&
+            data.trimColorImages[selectedTrim] &&
+            data.trimColorImages[selectedTrim][selectedColor]) {
+          img.src = data.trimColorImages[selectedTrim][selectedColor];
+        } else if (selectedColorImage) {
+          img.src = selectedColorImage;
+        }
       }
     });
   });
@@ -26,8 +34,16 @@ function initModelPage(data) {
         trimDetails.textContent = data.trims[trim] || '';
       }
       const img = document.querySelector('.model-card img');
-      if (!selectedColorImage && data.trimImages && data.trimImages[trim] && img) {
-        img.src = data.trimImages[trim];
+      if (img) {
+        if (data.trimColorImages && selectedColor &&
+            data.trimColorImages[selectedTrim] &&
+            data.trimColorImages[selectedTrim][selectedColor]) {
+          img.src = data.trimColorImages[selectedTrim][selectedColor];
+        } else if (selectedColorImage) {
+          img.src = selectedColorImage;
+        } else if (data.trimImages && data.trimImages[trim]) {
+          img.src = data.trimImages[trim];
+        }
       }
     };
     trimButtons.forEach(btn => {

--- a/VolvoPost/xc60.html
+++ b/VolvoPost/xc60.html
@@ -150,6 +150,23 @@
         'Core': 'images/xc60-core.jpg',
         'Plus': 'images/xc60-plus.jpg',
         'Ultra': 'images/xc60-ultra.jpg'
+      },
+      trimColorImages: {
+        'Core': {
+          'white': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/70700/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=carousel&angle=4&w=1920&bg=descriptive-studio',
+          'black': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/71700/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=carousel&angle=4&w=1920&bg=descriptive-studio',
+          'red': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio'
+        },
+        'Plus': {
+          'white': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/70700/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=carousel&angle=4&w=1920&bg=descriptive-studio',
+          'black': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/71700/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=carousel&angle=4&w=1920&bg=descriptive-studio',
+          'red': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio'
+        },
+        'Ultra': {
+          'white': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/70700/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=carousel&angle=4&w=1920&bg=descriptive-studio',
+          'black': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/71700/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=carousel&angle=4&w=1920&bg=descriptive-studio',
+          'red': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio'
+        }
       }
     });
     askModelYear();


### PR DESCRIPTION
## Summary
- support mapping images to both trim and color selections
- demonstrate `trimColorImages` on the XC60 page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687020036c408320aefe852eece726f0