### PR TITLE
Fix unique trim images on XC60 page

### DIFF
--- a/VolvoPost/xc60.html
+++ b/VolvoPost/xc60.html
@@ -147,9 +147,9 @@
         'Ultra': 'Air suspension, Bowers & Wilkins sound, 360° camera'
       },
       trimImages: {
-        'Core': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio',
-        'Plus': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio',
-        'Ultra': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio'
+        'Core': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/70700/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio',
+        'Plus': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/73100/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio',
+        'Ultra': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/73500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio'
       },
       trimColorImages: {
         'Core': {


### PR DESCRIPTION
## Summary
- update XC60 trimImages so each trim shows a different default picture

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68713fd8ae808320a33478576c3ec279