### PR TITLE
Enable wheel image swap on trim selection

### DIFF
--- a/VolvoPost/ex40.html
+++ b/VolvoPost/ex40.html
@@ -22,6 +22,7 @@
   <main class="container">
     <div class="model-card">
       <img src="images/ex40.avif" alt="Volvo EX40 electric SUV">
+      <img class="wheel-image" src="images/ex40-wheel-core.jpg" alt="Wheel design">
       <h2>EX40</h2>
       <p class="model-desc">All-electric evolution of the XC40 with agile performance and zero tailpipe emissions.</p>
       <p>Choose Trim:</p>
@@ -112,6 +113,11 @@
         'Core': 'images/ex40-core.jpg',
         'Plus': 'images/ex40-plus.jpg',
         'Ultra': 'images/ex40-ultra.jpg'
+      },
+      wheelImages: {
+        'Core': 'images/ex40-wheel-core.jpg',
+        'Plus': 'images/ex40-wheel-plus.jpg',
+        'Ultra': 'images/ex40-wheel-ultra.jpg'
       }
     });
   </script>

--- a/VolvoPost/main.css
+++ b/VolvoPost/main.css
@@ -253,6 +253,12 @@ footer {
   display: block;
 }
 
+.wheel-image {
+  width: 150px;
+  margin: 0.5em auto;
+  display: block;
+}
+
 .model-card h2 {
   margin: 0.8em 0 0.4em;
   color: var(--primary);

--- a/VolvoPost/script.js
+++ b/VolvoPost/script.js
@@ -2,6 +2,7 @@ function initModelPage(data) {
   const swatches = document.querySelectorAll('.color-swatch');
   const colorName = document.getElementById('color-name');
   const colorOptions = document.querySelector('.color-options');
+  const wheelImg = document.querySelector('.wheel-image');
   let selectedColor = null;
   let selectedColorImage = null;
   let selectedTrim = null;
@@ -29,6 +30,15 @@ function initModelPage(data) {
           img.src = selectedColorImage;
         }
       }
+      if (wheelImg) {
+        if (data.trimWheelColorImages && selectedTrim &&
+            data.trimWheelColorImages[selectedTrim] &&
+            data.trimWheelColorImages[selectedTrim][selectedColor]) {
+          wheelImg.src = data.trimWheelColorImages[selectedTrim][selectedColor];
+        } else if (data.wheelImages && selectedTrim && data.wheelImages[selectedTrim]) {
+          wheelImg.src = data.wheelImages[selectedTrim];
+        }
+      }
     });
   });
 
@@ -49,6 +59,9 @@ function initModelPage(data) {
         if (data.trimImages && data.trimImages[trim]) {
           img.src = data.trimImages[trim];
         }
+      }
+      if (wheelImg && data.wheelImages && data.wheelImages[trim]) {
+        wheelImg.src = data.wheelImages[trim];
       }
     };
     trimButtons.forEach(btn => {

--- a/VolvoPost/xc40.html
+++ b/VolvoPost/xc40.html
@@ -22,6 +22,7 @@
   <main class="container">
     <div class="model-card">
       <img src="images/VolvoXC40.jpg" alt="Volvo XC40 compact SUV">
+      <img class="wheel-image" src="images/xc40-wheel-core.jpg" alt="Wheel design">
       <h2>XC40</h2>
       <p class="model-desc">The Volvo XC40, our compact 5-seater SUV. It’s comfortable and perfectly sized for adventuring in the city or the open road.</p>
       <p>Choose Trim:</p>
@@ -124,6 +125,11 @@
         'Core': 'images/xc40-core.jpg',
         'Plus': 'images/xc40-plus.jpg',
         'Ultra': 'images/xc40-ultra.jpg'
+      },
+      wheelImages: {
+        'Core': 'images/xc40-wheel-core.jpg',
+        'Plus': 'images/xc40-wheel-plus.jpg',
+        'Ultra': 'images/xc40-wheel-ultra.jpg'
       }
     });
     askModelYear();

--- a/VolvoPost/xc90.html
+++ b/VolvoPost/xc90.html
@@ -22,6 +22,7 @@
   <main class="container">
     <div class="model-card">
       <img src="https://wizz.volvocars.com/images/2025/256/exterior/studio/threeQuartersFrontLeft/exterior-studio-threeQuartersFrontLeft_9F7D7C920353F190FE58ACFAA47F9BE421445171.png?client=carousel&w=1920" alt="Volvo XC90 three-row SUV">
+      <img class="wheel-image" src="images/xc90-wheel-core.jpg" alt="Wheel design">
       <h2>XC90</h2>
       <p class="model-desc">Flagship SUV with seating for seven and a choice of mild-hybrid or plug-in power.</p>
       <p>Choose Trim:</p>
@@ -129,6 +130,11 @@
         'Core': 'https://wizz.volvocars.com/images/2025/256/exterior/studio/threeQuartersFrontLeft/exterior-studio-threeQuartersFrontLeft_320F65959AE4D0A277F74DDCF0F00E5BBE3E89AF.png?client=vcus-americasemployeecarbooking&w=1080&imdensity=1',
         'Plus': 'https://wizz.volvocars.com/images/2025/256/exterior/studio/threeQuartersFrontLeft/exterior-studio-threeQuartersFrontLeft_1CA9775C94614653FC2A57B265AF0F4667031C49.png?client=vcus-americasemployeecarbooking&w=1080&imdensity=1',
         'Ultra': 'https://wizz.volvocars.com/images/2025/256/exterior/studio/threeQuartersFrontLeft/exterior-studio-threeQuartersFrontLeft_D3B6280D7ADBB943B8BE2EA3F47B0B225D6B13A2.png?client=vcus-americasemployeecarbooking&w=1080&imdensity=1'
+      },
+      wheelImages: {
+        'Core': 'images/xc90-wheel-core.jpg',
+        'Plus': 'images/xc90-wheel-plus.jpg',
+        'Ultra': 'images/xc90-wheel-ultra.jpg'
       }
     });
     askModelYear();


### PR DESCRIPTION
## Summary
- add support for wheel images per trim in `script.js`
- style `.wheel-image` in CSS
- update EX40, XC40 and XC90 pages to include wheel images
- configure wheel image mapping in each page

## Testing
- `python3 -m http.server 8000` *(fails: no output when not visited)*

------
https://chatgpt.com/codex/tasks/task_e_687156b19a9483209132ed5bd0bb76d5