### PR TITLE
Fix trim selector for XC60

### DIFF
--- a/VolvoPost/xc60.html
+++ b/VolvoPost/xc60.html
@@ -146,6 +146,11 @@
         'Plus': 'Keyless entry, leather upholstery, four-zone climate control',
         'Ultra': 'Air suspension, Bowers & Wilkins sound, 360° camera'
       },
+      trimImages: {
+        'Core': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio',
+        'Plus': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio',
+        'Ultra': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/72500/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=homepage&angle=4&w=1920&bg=descriptive-studio'
+      },
       trimColorImages: {
         'Core': {
           'white': 'https://cas.volvocars.com/image/dynamic/MY25_2417/246/exterior-v2/4D/70700/RD0000/R151/TC05/_/_/TP05/LR02/JT02/GR02/T102/TJ02/NP02/TM04/_/_/EV02/JB0B/T21B/LF05/_/VP08/_/FH02/T006/_/_/_/default.jpg?market=us&client=carousel&angle=4&w=1920&bg=descriptive-studio',


### PR DESCRIPTION
## Summary
- restore `trimImages` object so clicking a trim immediately updates the image on the XC60 page

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687903ae12dc8320b8cbdabc7f16d4de